### PR TITLE
Removing required heatId from finalizeCheck

### DIFF
--- a/src/ClubSpeed/Enterprise/EventsKarting/config/csek-ent.json
+++ b/src/ClubSpeed/Enterprise/EventsKarting/config/csek-ent.json
@@ -431,9 +431,6 @@
                         "properties": {
                             "checkDetailId": {
                                 "required": true
-                            },
-                            "heatId": {
-                                "required": true
                             }
                         }
                     }


### PR DESCRIPTION
heatId is not available when purchasing gift cards.